### PR TITLE
support "key" attribute in tag for alias

### DIFF
--- a/tests/ConsumerPassTest.php
+++ b/tests/ConsumerPassTest.php
@@ -101,6 +101,66 @@ class ConsumerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $definition->getMethodCalls());
     }
 
+    public function test_use_key()
+    {
+        $cb = $this->getContainer(new TagConsumerPass('tag.consumer'), array(
+            'my_service' => $this->getConsumerDefinition()->addTag('tag.consumer', array(
+                'tag' => 'dependency',
+                'method' => 'addDependencyWithAlias',
+                'key' => 'alias',
+            )),
+            'my_dep_1' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'second', ]),
+            'my_dep_2' => $this->getDependencyDefinition()->addTag('not_a_dependency'),
+            'my_dep_3' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'first', ]),
+        ));
+        $dependencies = $cb->get('my_service')->getDependencies();
+
+        $this->assertCount(2, $dependencies);
+        $this->assertContainsOnlyInstancesOf('StdClass', $dependencies);
+        $this->assertArrayHasKey('first', $dependencies);
+        $this->assertArrayHasKey('second', $dependencies);
+    }
+
+    public function test_bulk_use_key()
+    {
+        $cb = $this->getContainer(new TagConsumerPass('tag.consumer'), array(
+            'my_service' => $this->getConsumerDefinition()->addTag('tag.consumer', array(
+                'tag' => 'dependency',
+                'method' => 'setDependencies',
+                'bulk' => true,
+                'key' => 'alias',
+            )),
+            'my_dep_1' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'second', ]),
+            'my_dep_2' => $this->getDependencyDefinition()->addTag('not_a_dependency'),
+            'my_dep_3' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'first', ]),
+        ));
+        $dependencies = $cb->get('my_service')->getDependencies();
+
+        $this->assertCount(2, $dependencies);
+        $this->assertContainsOnlyInstancesOf('StdClass', $dependencies);
+        $this->assertArrayHasKey('first', $dependencies);
+        $this->assertArrayHasKey('second', $dependencies);
+    }
+
+    public function test_constructor_use_key()
+    {
+        $cb = $this->getContainer(new TagConsumerPass('tag.consumer'), array(
+            'my_service' => $this->getConsumerDefinition()->addTag('tag.consumer', array(
+                'tag' => 'dependency',
+                'key' => 'alias',
+            )),
+            'my_dep_1' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'second', ]),
+            'my_dep_2' => $this->getDependencyDefinition()->addTag('not_a_dependency'),
+            'my_dep_3' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'first', ]),
+        ));
+        $dependencies = $cb->get('my_service')->getDependencies();
+
+        $this->assertCount(2, $dependencies);
+        $this->assertContainsOnlyInstancesOf('StdClass', $dependencies);
+        $this->assertArrayHasKey('first', $dependencies);
+        $this->assertArrayHasKey('second', $dependencies);
+    }
+
     /**
      * @return Definition
      */
@@ -147,6 +207,11 @@ class MockedConsumerService
     public function addDependency($dependency)
     {
         $this->dependencies[] = $dependency;
+    }
+
+    public function addDependencyWithAlias($dependency, $alias)
+    {
+        $this->dependencies[$alias] = $dependency;
     }
 
     public function setDependencies(array $dependencies)


### PR DESCRIPTION
Add support for "key" in `TagConsumer`.
This defines the name of the field every provider can use to identify itself.

For example, when collecting this:
```yml
services:
    application:
        class: Symfony\Component\Console\Application
        tags:
            - name: "tag.consumer"
              tag: "console.command"
              method: "addCommands"
              bulk: true
              key: "alias"

command_1:
    class: Acme\Bundle\Command\MyFirstCommand
        tags:
            - name: "console.command"
              alias: "my_command"

command_2:
    class: Acme\Bundle\Command\MySecondCommand
        tags:
            - name: "console.command"
              alias: "second_command"
```

The key is defined as `alias`, so it should be used in `command_1`'s tag. The result is that `addCommands` will be called with an array indexed like `[ 'my_command' => …, 'second_command' => …, ]`.