### PR TITLE
Support "reference" attribute in tag.consumer

### DIFF
--- a/DependencyInjection/Compiler/TagConsumerPass.php
+++ b/DependencyInjection/Compiler/TagConsumerPass.php
@@ -76,7 +76,8 @@ class TagConsumerPass implements CompilerPassInterface
 
                 $tagName = $this->getAttribute($id, $tag, 'tag');
                 $key = isset($tag['key']) ? $tag['key'] : false;
-                $references = $this->getSortedDependencies($container, $tagName, $key);
+                $asReference = isset($tag['reference']) ? $tag['reference'] : true;
+                $references = $this->getSortedDependencies($container, $tagName, $key, $asReference);
                 $this->configureConsumer($definition, $tag, $references);
             }
         }
@@ -112,10 +113,11 @@ class TagConsumerPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param string           $tagName
      * @param string           $key
+     * @param bool             $asReference
      *
-     * @return Reference[]
+     * @return Reference[]|string[]
      */
-    private function getSortedDependencies(ContainerBuilder $container, $tagName, $key)
+    private function getSortedDependencies(ContainerBuilder $container, $tagName, $key, $asReference)
     {
         $ordered = array();
         $unordered = array();
@@ -123,7 +125,7 @@ class TagConsumerPass implements CompilerPassInterface
         $serviceIds = $container->findTaggedServiceIds($tagName);
         foreach ($serviceIds as $serviceId => $tags) {
 
-            $service = new Reference($serviceId);
+            $service = $asReference ? new Reference($serviceId) : $serviceId;
             foreach ($tags as $tag) {
 
                 if (isset($tag['order']) && is_numeric($tag['order'])) {

--- a/tests/ConsumerPassTest.php
+++ b/tests/ConsumerPassTest.php
@@ -161,6 +161,26 @@ class ConsumerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('second', $dependencies);
     }
 
+    public function test_service_names_when_reference_is_false()
+    {
+        $cb = $this->getContainer(new TagConsumerPass('tag.consumer'), array(
+            'my_service' => $this->getConsumerDefinition()->addTag('tag.consumer', array(
+                'tag' => 'dependency',
+                'key' => 'alias',
+                'reference' => false,
+            )),
+            'my_dep_1' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'second', ]),
+            'my_dep_2' => $this->getDependencyDefinition()->addTag('not_a_dependency'),
+            'my_dep_3' => $this->getDependencyDefinition()->addTag('dependency', [ 'alias' => 'first', ]),
+        ));
+        $dependencies = $cb->get('my_service')->getDependencies();
+
+        $this->assertCount(2, $dependencies);
+        $this->assertContainsOnly('string', $dependencies);
+        $this->assertContains('my_dep_1', $dependencies);
+        $this->assertContains('my_dep_3', $dependencies);
+    }
+
     /**
      * @return Definition
      */


### PR DESCRIPTION
Consumer tags now allow an optional attribute `reference`.
By default this attribute is `true` and keeps compatibility with previous definitions.
When this is `false`, service ids will be injected to the consumer, not service references.
This may help in case you're making a service locator, for example.

Kudos to @andresroro for the idea